### PR TITLE
Logs fix : display http:// instead of tcp:// for listening message. 

### DIFF
--- a/src/app.cr
+++ b/src/app.cr
@@ -39,7 +39,7 @@ Signal::INT.trap do
 end
 
 # Start the server
-puts "Listening on tcp://#{host}:#{port}"
+puts "Listening on http://#{host}:#{port}"
 server.run
 
 # Shutdown message


### PR DESCRIPTION
Useful for clicking it directly on the log.
You can then open browser on the app quickly

Sorry it's not a huge participation ;)