### PR TITLE
Change shard name to spider-gazelle

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,4 +1,4 @@
-name: app
+name: spider-gazelle
 version: 1.0.0
 
 dependencies:


### PR DESCRIPTION
The name property in `shard.yml` is supposed to declare the specific name of a shard. It should not be a placeholder.

shardbox.org for example indexes shards by their name, which means spider-gazelle is currently labeld "app" (https://shardbox.org/shards/app).